### PR TITLE
feat(cleanup_script.sh): add more debug info and increase image count

### DIFF
--- a/roles/runner_configuration/files/cleanup_script.sh
+++ b/roles/runner_configuration/files/cleanup_script.sh
@@ -13,16 +13,15 @@ ls -al "$RUNNER_TEMP"
 echo
 
 # Check if RUNNER_TEMP is set and the directory exists
-if [[ -n "$RUNNER_TEMP" && -d "$RUNNER_TEMP" ]]; then
+if [[ -n $RUNNER_TEMP && -d $RUNNER_TEMP ]]; then
     echo "Cleaning up contents of: $RUNNER_TEMP"
 
     # Remove all contents but not the folder itself
     sudo rm -rf "${RUNNER_TEMP:?}/"*
-    sudo rm -rf "${RUNNER_TEMP:?}/".* 2>/dev/null || true  # Remove hidden files, skip . and ..
+    sudo rm -rf "${RUNNER_TEMP:?}/".* 2>/dev/null || true # Remove hidden files, skip . and ..
 else
     echo "RUNNER_TEMP is not set or does not exist. Skipping cleanup."
 fi
-
 
 # Number of most recent images to keep
 keep_last_x=15
@@ -33,11 +32,11 @@ echo
 
 # Get all unique image IDs
 echo "Collecting unique image metadata..."
-image_list=$(docker images --format '{{.ID}}' | sort | uniq | \
-while read -r id; do
-    created=$(docker inspect --format '{{.Created}}' "$id" 2>/dev/null)
-    echo "$created $id"
-done | sort -r)
+image_list=$(docker images --format '{{.ID}}' | sort | uniq |
+    while read -r id; do
+        created=$(docker inspect --format '{{.Created}}' "$id" 2>/dev/null)
+        echo "$created $id"
+    done | sort -r)
 
 # Preview images to be removed
 echo "=== STEP 2: Images That Will Be REMOVED (Keeping last $keep_last_x) ==="

--- a/roles/runner_configuration/files/cleanup_script.sh
+++ b/roles/runner_configuration/files/cleanup_script.sh
@@ -1,5 +1,55 @@
 #!/bin/bash
 
-keep_last_x=4
-# List all images, sort by creation date, get the image IDs, skip the last x, and remove the rest
-docker images --format "{{.CreatedAt}} {{.ID}}" | sort -r | awk '{print $5}' | tail -n +$((keep_last_x + 1)) | xargs -r docker rmi -f
+echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+
+ls -al "$GITHUB_WORKSPACE"
+
+echo
+
+echo "RUNNER_TEMP=$RUNNER_TEMP"
+
+ls -al "$RUNNER_TEMP"
+
+echo
+
+# Check if RUNNER_TEMP is set and the directory exists
+if [[ -n "$RUNNER_TEMP" && -d "$RUNNER_TEMP" ]]; then
+    echo "Cleaning up contents of: $RUNNER_TEMP"
+
+    # Remove all contents but not the folder itself
+    sudo rm -rf "${RUNNER_TEMP:?}/"*
+    sudo rm -rf "${RUNNER_TEMP:?}/".* 2>/dev/null || true  # Remove hidden files, skip . and ..
+else
+    echo "RUNNER_TEMP is not set or does not exist. Skipping cleanup."
+fi
+
+
+# Number of most recent images to keep
+keep_last_x=15
+
+echo "=== STEP 1: All Docker Images (Before Cleanup) ==="
+docker images --format 'Repository: {{.Repository}} | Tag: {{.Tag}} | ID: {{.ID}} | Created: {{.CreatedSince}} | Size: {{.Size}}'
+echo
+
+# Get all unique image IDs
+echo "Collecting unique image metadata..."
+image_list=$(docker images --format '{{.ID}}' | sort | uniq | \
+while read -r id; do
+    created=$(docker inspect --format '{{.Created}}' "$id" 2>/dev/null)
+    echo "$created $id"
+done | sort -r)
+
+# Preview images to be removed
+echo "=== STEP 2: Images That Will Be REMOVED (Keeping last $keep_last_x) ==="
+to_remove=$(echo "$image_list" | tail -n +$((keep_last_x + 1)))
+echo "$to_remove" | awk '{printf "ID: %s | Created: %s\n", $2, $1}'
+
+# Actually remove them
+echo
+echo "Removing images..."
+echo "$to_remove" | awk '{print $2}' | xargs -r docker rmi -f
+echo
+
+# Show remaining images
+echo "=== STEP 3: Remaining Docker Images (After Cleanup) ==="
+docker images --format 'Repository: {{.Repository}} | Tag: {{.Tag}} | ID: {{.ID}} | Created: {{.CreatedSince}} | Size: {{.Size}}'


### PR DESCRIPTION
## Description

- This increases the count of available images from 4 to 15, because we have the space.
- Makes the image list and remove process more descriptive and transparent.
- Cleans up contents of `$RUNNER_TEMP`: `/opt/actions-runner/_work/_temp` they created problems as they persisted.
- Also logs the contents of `$GITHUB_WORKSPACE` for debugging purposes.

## How was this PR tested?

- https://github.com/autowarefoundation/autoware_universe/actions/runs/15156231173/job/42611643057#step:2:1

## Notes for reviewers

None.

## Effects on system behavior

None.
